### PR TITLE
Add Bootstrap Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,19 @@ Additionally, [these instructions](https://hackernoon.com/raspberry-pi-headless-
 
 ### Installing RPiLight
 
-First, we will need to make sure git is installed.
+RPiLight includes a bootstrapping script that can install Swift and its dependencies, build, and install RPiLight for the first time.
 ```
-sudo apt-get install git
-```
-
-Then, we can
-```
-cd ~
-git clone https://github.com/Kaiede/RPiLight.git
-cd RPiLight
-./install.sh full
+source <(curl -s https://raw.githubusercontent.com/Kaiede/RPiLight/master/bootstrap.sh)
 ```
 
-The `./install.sh full` command only needs to be run the first time an install is done, or during major updates, as it installs things that RPiLight requires using apt-get, and grabs the version of Swift needed to build. When making changes
-
-When updating, you can use:
+Once bootstrapped, it is possible to get the latest source and update using `install.sh`:
 ```
 ./install.sh update
 ```
 
-This command pulls the latest source from GitHub, builds it, and installs it. 
-
 ## Configuring RPiLight
 
-There are example configuration files in the [example](examples) folder. These files are JSON-formatted. Let's go ahead and break down one of those examples:
+There are example configuration files in the [examples](examples) folder. These files are JSON-formatted. Let's go ahead and break down one of those examples:
 
 ### Hardware
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,7 +62,7 @@ function install_swift() {
 		sudo mkdir -p /opt/swift
 	fi
 	pushd /opt/swift > /dev/null
-	pv "$SWIFT_TARBALL" | sudo tar -zxf - --strip-components=$COMPONENT_NUM 
+	pv "$SWIFT_TARBALL" | sudo tar -zx --strip-components=$COMPONENT_NUM 
 	popd > /dev/null
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,7 +62,7 @@ function install_swift() {
 		sudo mkdir -p /opt/swift
 	fi
 	pushd /opt/swift > /dev/null
-	sudo pv "$SWIFT_TARBALL" | tar -zxf --strip-components=$COMPONENT_NUM -
+	pv "$SWIFT_TARBALL" | sudo tar -zxf --strip-components=$COMPONENT_NUM -
 	popd > /dev/null
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Bootstraps RPiLight on a Fresh Raspberry Pi
+#
+
+#
+# Setup Pre-Requisites
+#
+function install_dependencies() {
+    echo "Installing Dependencies..."
+    sudo apt-get install --yes \
+                    autoconf \
+                    clang-3.8 \
+                    cmake \
+                    git \
+                    icu-devtools \
+                    libblocksruntime-dev \
+                    libbsd-dev \
+                    libcurl4-openssl-dev \
+                    libedit-dev \
+                    libicu-dev \
+                    libncurses5-dev \
+                    libpthread-workqueue-dev \
+                    libpython-dev \
+                    libsqlite3-dev \
+                    libtool \
+                    libxml2-dev \
+                    ninja-build \
+                    pkg-config \
+                    pv \
+                    python \
+                    swig \
+                    systemtap-sdt-dev \
+                    uuid-dev	
+}
+
+#
+# Install Swift
+#
+function install_swift() {
+	PROCESSOR=$(uname -m)
+	SWIFT_TARBALL=$(realpath swift3_binaries.tgz)
+	COMPONENT_NUM=2
+
+	if [ "$PROCESSOR" == "armv6l" ]; then
+		echo "Downloading Swift 3.1.1 for ARMv6..."
+		curl -L -o "$SWIFT_TARBALL" https://www.dropbox.com/s/r7a97yh1h7hc059/swift-3.1.1-Rpi1armv6-RaspbianStretchAug17_dispatchfix.tgz?dl=1
+	elif [ "$PROCESSOR" == "armv7l" ]; then
+		echo "Downloading Swift 3.1.1 for ARMv7..."
+		curl -L -o "$SWIFT_TARBALL" https://www.dropbox.com/s/z7uihfx2bcbuurw/swift-3.1.1-RPi23-RaspbianStretchAug17.tgz?dl=1
+	else
+		echo "Unknown Processor. RPiLight may not work."
+		exit 1
+	fi
+
+	echo "Installing Swift into /opt/swift/..."
+	if [ ! -d "/opt/swift" ]; then
+		sudo mkdir -p /opt/swift
+	fi
+	pushd /opt/swift > /dev/null
+	sudo pv "$SWIFT_TARBALL" | tar -zxf -
+	popd > /dev/null
+}
+
+function add_swift_path() {
+	PROFILE_PATH=$(realpath ~/.bash_profile)
+
+	echo "Adding /opt/swift/bin to ~/.bash_profile..."
+	touch $PROFILE_PATH
+	echo "#" >> $PROFILE_PATH
+	echo "# Swift Binaries" >> $PROFILE_PATH
+	echo "#" >> $PROFILE_PATH
+	echo "export PATH=\$PATH:/opt/swift/bin" >> $PROFILE_PATH
+	source $PROFILE_PATH
+
+	export PATH
+}
+
+#
+# Script Flow
+#
+cd ~
+install_dependencies
+install_swift
+add_swift_path
+
+git clone https://github.com/Kaiede/RPiLight.git
+pushd ~/RPiLight > /dev/null
+./install.sh 
+popd > /dev/null

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,7 +62,7 @@ function install_swift() {
 		sudo mkdir -p /opt/swift
 	fi
 	pushd /opt/swift > /dev/null
-	pv "$SWIFT_TARBALL" | sudo tar --strip-components=$COMPONENT_NUM -zxf  -
+	pv "$SWIFT_TARBALL" | sudo tar -zxf - --strip-components=$COMPONENT_NUM 
 	popd > /dev/null
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,6 +32,10 @@ function install_dependencies() {
                     swig \
                     systemtap-sdt-dev \
                     uuid-dev	
+
+
+	sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100
+	sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 }
 
 #
@@ -58,7 +62,7 @@ function install_swift() {
 		sudo mkdir -p /opt/swift
 	fi
 	pushd /opt/swift > /dev/null
-	sudo pv "$SWIFT_TARBALL" | tar -zxf -
+	sudo pv "$SWIFT_TARBALL" | tar -zxf --strip-components=$COMPONENT_NUM -
 	popd > /dev/null
 }
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,7 +62,7 @@ function install_swift() {
 		sudo mkdir -p /opt/swift
 	fi
 	pushd /opt/swift > /dev/null
-	pv "$SWIFT_TARBALL" | sudo tar -zxf --strip-components=$COMPONENT_NUM -
+	pv "$SWIFT_TARBALL" | sudo tar --strip-components=$COMPONENT_NUM -zxf  -
 	popd > /dev/null
 }
 

--- a/install.sh
+++ b/install.sh
@@ -36,13 +36,11 @@ function install_rpilight() {
 		sudo mkdir -p "$RPILIGHT_DEST/config"
 	fi
 
-	echo "Copying Binaries to $RPILIGHT_DEST"
+	echo "Copying Binary to $RPILIGHT_DEST"
 	sudo cp "$RPILIGHT_BINARY" "$RPILIGHT_DEST"
 
 	echo "Copying Examples to $RPILIGHT_DEST"
-	sudo rm -rf "$RPLIGHT_DEST/examples"
-	sudo mkdir "$RPLIGHT_DEST/examples"
-	sudo cp -r "$RPILIGHT_EXAMPLES" "$RPLIGHT_DEST/examples"
+	sudo rsync --delete -r examples/ /opt/rpilight/examples/
 
 	SERVICE_DEST="/lib/systemd/system"
 	echo "Copying Service Configuration to $SERVICE_DEST" 

--- a/install.sh
+++ b/install.sh
@@ -1,89 +1,7 @@
 #!/bin/bash
 #
+# Installer Script 
 #
-#
-
-#
-# Prerequisites for Swift
-#
-function install_swift_prereqs() {
-	echo "Installing Dependencies for Swift..."
-	sudo apt-get install git cmake ninja-build clang-3.8 python uuid-dev libicu-dev icu-devtools libbsd-dev libedit-dev libxml2-dev libsqlite3-dev swig libpython-dev libncurses5-dev pkg-config libblocksruntime-dev libcurl4-openssl-dev autoconf libtool systemtap-sdt-dev libpthread-workqueue-dev
-
-	sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100
-	sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
-
-#	Needed for the Swift 4.1.2 Binaries
-# 	curl -O http://launchpadlibrarian.net/234848656/libicu55_55.1-7_armhf.deb
-#	sudo dpkg -i libicu55_55.1-7_armhf.deb
-}
-
-#
-# Swift 3.1.1 Prerequisite
-#
-function install_swift() {
-	PROCESSOR=$(uname -m)
-	SWIFT3_TARBALL=$(realpath swift3_binaries.tgz)
-	SWIFT4_TARBALL=$(realpath swift4_binaries.tgz)
-
-	if [ -f "$SWIFT4_TARBALL" ]; then
-		SWIFT_TARBALL=$SWIFT4_TARBALL
-		COMPONENT_NUM=1
-		echo "Swift 4 Tarball Found: $SWIFT_TARBALL"
-	elif [ -f "$SWIFT3_TARBALL" ]; then
-		SWIFT_TARBALL=$SWIFT3_TARBALL
-		COMPONENT_NUM=2
-		echo "Swift 3 Tarball Found: $SWIFT_TARBALL"
-	elif [ "$PROCESSOR" == "armv6l" ]; then
-		SWIFT_TARBALL=$SWIFT3_TARBALL
-		COMPONENT_NUM=2
-		echo "Downloading Swift 3.1.1 for ARMv6"
-		curl -L -o "$SWIFT_TARBALL" https://www.dropbox.com/s/r7a97yh1h7hc059/swift-3.1.1-Rpi1armv6-RaspbianStretchAug17_dispatchfix.tgz?dl=1
-	elif [ "$PROCESSOR" == "armv7l" ]; then
-		SWIFT_TARBALL=$SWIFT3_TARBALL
-		COMPONENT_NUM=2
-		echo "Downloading Swift 3.1.1 for ARMv7"
-		curl -L -o "$SWIFT_TARBALL" https://www.dropbox.com/s/z7uihfx2bcbuurw/swift-3.1.1-RPi23-RaspbianStretchAug17.tgz?dl=1
-#		SWIFT_TARBALL=$SWIFT4_TARBALL
-#		COMPONENT_NUM=1
-#		echo "Downloading Swift 4.1.2 for ARMv7"
-#		curl -L -o "$SWIFT_TARBALL" https://www.dropbox.com/s/7fje6x1l8p519mx/swift-4.1.2-RPi23-RaspbianStretch_b3.tgz?dl=1
-	else
-		echo "Unknown Processor. RPiLight may not work."
-		exit 1
-	fi
-
-	echo "Installing Swift into /opt/swift/..."
-	if [ ! -d "/opt/swift" ]; then
-		sudo mkdir -p /opt/swift
-	fi
-	pushd /opt/swift > /dev/null
-	sudo tar -xvf $SWIFT_TARBALL --strip-components=$COMPONENT_NUM
-	popd > /dev/null
-}
-
-#
-# Configure PATH if Needed
-#
-function check_path() {
-	PROFILE_PATH=$(realpath ~/.bash_profile)
-	source $PROFILE_PATH
-
-	if [[ ":$PATH:" == *":/opt/swift/bin:"* && -f $PROFILE_PATH ]]; then
-		echo "Path Already Configured..."
-		return
-	fi
-
-	echo "Configuring .bash_profile..."
-	touch $PROFILE_PATH
-	echo "#" >> $PROFILE_PATH
-	echo "# Swift Binaries" >> $PROFILE_PATH
-	echo "#" >> $PROFILE_PATH
-	echo "export PATH=\$PATH:/opt/swift/bin" >> $PROFILE_PATH
-	source $PROFILE_PATH
-
-	export PATH
-}
 
 #
 # Grab Latest Git State
@@ -106,6 +24,7 @@ function build_rpilight() {
 #
 function install_rpilight() {
 	RPILIGHT_BINARY=$(realpath .build/release/RPiLight)
+	RPILIGHT_EXAMPLES=$(realpath examples)
 	RPILIGHT_SERVICE=$(realpath rpilight.service)
 
 	RPILIGHT_DEST="/opt/rpilight"
@@ -119,6 +38,9 @@ function install_rpilight() {
 
 	echo "Copying Binaries to $RPILIGHT_DEST"
 	sudo cp "$RPILIGHT_BINARY" "$RPILIGHT_DEST"
+
+	echo "Copying Examples to $RPILIGHT_DEST"
+	sudo cp "$RPILIGHT_EXAMPLES" "$RPLIGHT_DEST/examples"
 
 	SERVICE_DEST="/lib/systemd/system"
 	echo "Copying Service Configuration to $SERVICE_DEST" 
@@ -145,7 +67,7 @@ INSTALL_MODE="default"
 SCRIPT_PATH=$(realpath $0)
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 
-if [ "$1" == "full" ] || [ "$1" == "update" ]; then
+if [ "$1" == "update" ]; then
 	INSTALL_MODE="$1"
 fi
 
@@ -153,14 +75,7 @@ echo "RPiLight Directory: $SCRIPT_DIR"
 echo "Install Mode: $INSTALL_MODE"
 pushd "$SCRIPT_DIR" > /dev/null
 
-check_path
-
-if [ "$INSTALL_MODE" == "full" ]; then
-	install_swift_prereqs
-	install_swift
-fi
-
-if [ "$INSTALL_MODE" == "full" ] || [ "$INSTALL_MODE" == "update" ]; then
+if [ "$INSTALL_MODE" == "update" ]; then
 	update_source
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,9 @@ function install_rpilight() {
 	sudo cp "$RPILIGHT_BINARY" "$RPILIGHT_DEST"
 
 	echo "Copying Examples to $RPILIGHT_DEST"
-	sudo cp "$RPILIGHT_EXAMPLES" "$RPLIGHT_DEST/examples"
+	sudo rm -rf "$RPLIGHT_DEST/examples"
+	sudo mkdir "$RPLIGHT_DEST/examples"
+	sudo cp -r "$RPILIGHT_EXAMPLES" "$RPLIGHT_DEST/examples"
 
 	SERVICE_DEST="/lib/systemd/system"
 	echo "Copying Service Configuration to $SERVICE_DEST" 


### PR DESCRIPTION
The bootstrap script handles pre-requisites and initial setup required to build RPiLight.

It makes it possible to take a fresh Raspbian Lite install, and get an installed build of RPiLight in a single command.