### PR TITLE
Make Unit Tests Quieter

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -136,7 +136,30 @@ public struct Log {
         Log.logLevel = level
     }
 
-    private static var logLevel: LogLevel = .info
+    public static func pushLevel(_ level: LogLevel) {
+        Log.logLevelStack.append(level)
+    }
+
+    public static func popLevel() {
+        let _ = Log.logLevelStack.popLast()
+    }
+
+    private static var logLevelStack: [LogLevel] = []
+
+    private static var logLevel: LogLevel {
+        get {
+            return Log.logLevelStack.last ?? .info
+        }
+        set {
+            let count = Log.logLevelStack.count
+            if count > 0 {
+                Log.logLevelStack[count - 1] = newValue
+            } else {
+                Log.logLevelStack.append(newValue)
+            }
+        }
+    }
+
     private static func shouldLog(_ level: LogLevel) -> Bool {
         return level >= Log.logLevel
     }

--- a/Sources/Service/LightController.swift
+++ b/Sources/Service/LightController.swift
@@ -119,7 +119,7 @@ public class LightController: BehaviorController {
 
         // Configure Dispatch Queue
         self.queue = DispatchQueue(label: "rpilight.controller",
-                                   qos: .userInitiated,
+                                   qos: .userInteractive,
                                    attributes: [],
                                    autoreleaseFrequency: .inherit,
                                    target: nil)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,9 +1,6 @@
 import XCTest
-import Logging
 @testable import ServiceTests
 @testable import LEDTests
-
-Log.setLoggingLevel(.warn)
 
 XCTMain([
     // LED Tests

--- a/Tests/ServiceTests/BehaviorTests.swift
+++ b/Tests/ServiceTests/BehaviorTests.swift
@@ -25,6 +25,9 @@
 
 import XCTest
 import Dispatch
+
+import LED
+import Logging
 @testable import Service
 
 extension DispatchTimeInterval {
@@ -84,6 +87,14 @@ class MockBehaviorChannel: BehaviorChannel {
 }
 
 class BehaviorTests: XCTestCase {
+    override class func setUp() {
+        Log.pushLevel(.warn)
+    }
+
+    override class func tearDown() {
+        Log.popLevel()
+    }
+
     func testDefaultRefresh() {
         let testBehavior = DefaultLightBehavior()
 

--- a/Tests/ServiceTests/LayerTests.swift
+++ b/Tests/ServiceTests/LayerTests.swift
@@ -24,6 +24,9 @@
  */
 
 import XCTest
+
+import LED
+import Logging
 @testable import Service
 
 struct MockLayerPoint: LayerPoint {
@@ -46,6 +49,14 @@ struct MockLayerPoint: LayerPoint {
 }
 
 class LayerTests: XCTestCase {
+    override class func setUp() {
+        Log.pushLevel(.warn)
+    }
+
+    override class func tearDown() {
+        Log.popLevel()
+    }
+
     func testActiveIndex() {
         // Segments are considered such that they don't include their start, but do include their end.
         // It's not intuitive, hence these tests.

--- a/Tests/ServiceTests/LightControllerTests.swift
+++ b/Tests/ServiceTests/LightControllerTests.swift
@@ -154,6 +154,8 @@ class LightControllerTests: XCTestCase {
     }
 
     func testForceStop() {
+        Log.pushLevel(.debug)
+
         let mockController = MockBehaviorController(channelCount: 4)
         let mockBehavior = MockBehavior()
         mockBehavior.intervalMs = 1000
@@ -170,6 +172,8 @@ class LightControllerTests: XCTestCase {
             // Shouldn't have waited until a refresh to stop the controller
             XCTAssertFalse(mockBehavior.didStop)
         }
+
+        Log.popLevel()
     }
 
     func testOneShot() {

--- a/Tests/ServiceTests/LightControllerTests.swift
+++ b/Tests/ServiceTests/LightControllerTests.swift
@@ -24,6 +24,9 @@
  */
 
 import XCTest
+
+import LED
+import Logging
 @testable import Service
 
 class MockBehavior: Behavior {
@@ -100,6 +103,14 @@ class MockOneShotBehavior: Behavior {
 }
 
 class LightControllerTests: XCTestCase {
+    override class func setUp() {
+        Log.pushLevel(.warn)
+    }
+
+    override class func tearDown() {
+        Log.popLevel()
+    }
+
     func testChannelEvent() {        
         // This ensures we know that we are actually getting brightness, not intensity.
         let mockConfiguration = LightControllerConfig(gamma: 2.0)


### PR DESCRIPTION
This provides more consistent quieting of the test output while running. Someone can easily change this locally if they want to see more logging during a particular test. But as the test count grows, this can get pretty ridiculous.